### PR TITLE
Paufinage SQL import bib_noms

### DIFF
--- a/docs/install_all/2016-12-exemple-deploiement-pnr.rst
+++ b/docs/install_all/2016-12-exemple-deploiement-pnr.rst
@@ -226,6 +226,9 @@ Idem avec les autres tables de geonaturedb qui contiennent quelques données exe
         INSERT INTO taxonomie.bib_noms (cd_nom,cd_ref,nom_francais) 
         SELECT DISTINCT	rnf.taxon_mnhn_id, t.cd_ref, t.nom_vern FROM serena_affo_pnr_vm.rnf_obse_geom rnf
         JOIN taxonomie.taxref t ON t.cd_nom = rnf.taxon_mnhn_id
+        -- pour éviter les doublons si des espèces sont déjà présentes dans bib_noms :
+        LEFT JOIN taxonomie.bib_noms tb ON tb.cd_nom = rnf.cd_nom
+        WHERE tb.cd_nom IS NULL
 
 Attention il semblerait que 39 taxons n'aient pas été intégrés, certainement car ils n'ont pas d'identifiant taxref ? A vérifier. 
 


### PR DESCRIPTION
Ajout d'une condition dans la requête pour éviter la création de doublons si la table bib_noms est déjà peuplée